### PR TITLE
chore: GraphQL Schema でリソースの識別子フィールドを ID にした

### DIFF
--- a/src/task/task.graphql
+++ b/src/task/task.graphql
@@ -1,37 +1,104 @@
+""" タスク """
 type Task {
+  """ 外部 ID """
   id: ID!
+
+  """
+  タスクの概要
+  MEMO: summary のほうが適切かもしれない
+  """
   title: String!
+
+  """ タスクの詳細 """
   description: String!
+
+  """ タスクが完了したか否か """
   done: Boolean!
+
+  """
+  タスクを作成したユーザー
+  現時点では自分のタスクのみを管理する前提なので、Asignee や Reporter の区別は必要ない
+  """
   owner: User!
 
+  """ タスクの締め切り日時(UNIX時間) """
   deadlineAt: Int
+
+  """ タスクの作成日時(UNIX時間) """
   createdAt: Int!
+
+  """ タスクの最終更新日時(UNIX時間) """
   updatedAt: Int!
 }
 
+""" タスクの作成に必要な情報 """
 input CreateTaskInput {
+  """
+  タスクの概要
+  MEMO: summary のほうが適切かもしれない
+  """
   title: String!
+
+  """ タスクの詳細 """
   description: String!
+
+  """ タスクが完了したか否か """
   done: Boolean!
-  ownerId: String!
+
+  """
+  タスクを作成したユーザーの ID
+  現時点では自分のタスクのみを管理する前提なので、Asignee や Reporter の区別は必要ない
+  """
+  ownerId: ID!
+
+  """ タスクの締め切り日時(UNIX時間) """
   deadlineAt: Int
 }
 
+"""
+タスク情報の更新に必要な情報
+完了したか否かは専用の mutation で管理する。
+現時点の設計ではユーザー間でタスクの移譲は不可。
+"""
 input UpdateTaskInput {
+  """
+  タスクの概要
+  MEMO: summary のほうが適切かもしれない
+  """
   title: String!
+
+  """ タスクの詳細 """
   description: String!
+
+  """ タスクの締め切り日時(UNIX時間) """
   deadlineAt: Int
 }
 
 type Query {
+  """
+  タスクの一覧取得
+  FIXME: システムに保存されているすべてのタスクの一覧を取得することはないので、引数で ownerId を受け取るようにする
+  TODO(enhancement): GraphQL のプラクティスに沿った Pagination を実装する
+  """
   tasks: [Task]!
+
+  """ 外部 ID を用いて一意のタスクを取得する """
   task(id: ID!): Task
 }
 
 type Mutation {
+  """ タスク作成 """
   createTask(createTaskInput: CreateTaskInput!): Task!
+
+  """ タスク更新 """
   updateTask(updateTaskInput: UpdateTaskInput!): Task!
+
+  """
+  タスクを完了状態にする
+  TODO(enhancement): タスクを未完了状態にする mutation を実装する
+  """
   didTask(id: ID!): Task!
+
+  """ タスク論理削除 """
   removeTask(id: ID!): Boolean!
 }

--- a/src/task/task.graphql
+++ b/src/task/task.graphql
@@ -1,12 +1,10 @@
 type Task {
-  """ TODO(enhancement): UUID 型にする """
-  id: String!
+  id: ID!
   title: String!
   description: String!
   done: Boolean!
   owner: User!
 
-  """ TODO(enhancement): Data 型にする """
   deadlineAt: Int
   createdAt: Int!
   updatedAt: Int!
@@ -28,12 +26,12 @@ input UpdateTaskInput {
 
 type Query {
   tasks: [Task]!
-  task(id: String!): Task
+  task(id: ID!): Task
 }
 
 type Mutation {
   createTask(createTaskInput: CreateTaskInput!): Task!
   updateTask(updateTaskInput: UpdateTaskInput!): Task!
-  didTask(id: String!): Task!
-  removeTask(id: String!): Boolean!
+  didTask(id: ID!): Task!
+  removeTask(id: ID!): Boolean!
 }

--- a/src/user/user.graphql
+++ b/src/user/user.graphql
@@ -1,26 +1,54 @@
+"""
+サービス利用者
+TODO(enhancement): 作成日時・更新日時フィールドの追加
+"""
 type User {
+  """ 外部ID """
   id: ID!
+
+  """ ユーザー名 """
   name: String!
+
+  """ ユーザーの年齢（非負整数） """
   age: Int!
 }
 
+""" ユーザー登録に必要なデータ """
 input CreateUserInput {
+  """ ユーザー名 """
   name: String!
+
+  """ ユーザー名 """
   age: Int!
 }
 
+""" ユーザー情報更新に必要なデータ """
 input UpdateUserInput {
+  """ ユーザー名 """
   name: String!
+
+  """ ユーザー名 """
   age: Int!
 }
 
 type Query {
+  """
+  ユーザーの一覧取得
+  TODO(enhancement): GraphQL のプラクティスに沿った Pagination を実装する
+  """
   users: [User]!
+
+  """ 外部 ID を用いて一意のユーザー情報を取得する """
   user(id: ID!): User
 }
 
 type Mutation {
+  """ ユーザー作成 """
   createUser(createUserInput: CreateUserInput!): User!
+
+  """ ユーザー情報更新 """
   updateUser(id: ID!, updateUserInput: UpdateUserInput!): User!
+
+  """ ユーザー論理削除 """
   removeUser(id: ID!): Boolean!
 }

--- a/src/user/user.graphql
+++ b/src/user/user.graphql
@@ -1,5 +1,5 @@
 type User {
-  id: String!
+  id: ID!
   name: String!
   age: Int!
 }
@@ -16,11 +16,11 @@ input UpdateUserInput {
 
 type Query {
   users: [User]!
-  user(id: String!): User
+  user(id: ID!): User
 }
 
 type Mutation {
   createUser(createUserInput: CreateUserInput!): User!
-  updateUser(id: String!, updateUserInput: UpdateUserInput!): User!
-  removeUser(id: String!): Boolean!
+  updateUser(id: ID!, updateUserInput: UpdateUserInput!): User!
+  removeUser(id: ID!): Boolean!
 }


### PR DESCRIPTION
# Merge commit message

各リソースの `id` フィールドの型を `ID` にしたり、Doc comment を追加することで GraphQL のプラクティスに沿った Schema にした。
`nest/apollo` の処理では `ID` は `string` として処理される。