### PR TITLE
fix: monorepo 準備の際にコード生成スクリプトのファイルパスを変更していなかった

### DIFF
--- a/packages/api/scripts/codegen.sh
+++ b/packages/api/scripts/codegen.sh
@@ -2,6 +2,6 @@
 
 pushd `dirname $0`
 
-npx ts-node ./generate-typing.ts
+npx ts-node ./scripts/generate-typing.ts
 
 popd

--- a/packages/api/scripts/generate-typing.ts
+++ b/packages/api/scripts/generate-typing.ts
@@ -5,11 +5,11 @@
 import { GraphQLDefinitionsFactory } from '@nestjs/graphql';
 import { join } from 'path';
 
-const SRC_DIR = join(process.cwd(), '..', 'src');
+const SRC_DIR = join(__dirname, '..', 'src');
 
 const definitionsFactory = new GraphQLDefinitionsFactory();
 definitionsFactory.generate({
-  typePaths: [join(SRC_DIR, '**/*.graphql')],
+  typePaths: [join(SRC_DIR, '**', '*.graphql')],
   path: join(SRC_DIR, 'graphql.autogen.ts'),
   outputAs: 'class',
 });


### PR DESCRIPTION
related to #8 

# Merge commit message

monorepo の準備のためにディレクトリ構成を変更したが、その変更を GraphQL 用型生成スクリプトに適用できていなかった。